### PR TITLE
Investigate metadata injection for app identification

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1522,6 +1522,21 @@ generate_chat_completion = chat_completion
 def _create_zhealth_log_entry(user, model_id: str | None, form_data: dict):
     """Create initial zhealth log entry and return log_id."""
     try:
+        # Extract optional app_metadata from request
+        app_metadata = form_data.get("app_metadata")
+        
+        # Build base log metadata
+        log_metadata = {
+            "api_version": "v1",
+            "endpoint": "/api/zhealth/v1/chat/completions",
+            "user_role": user.role,
+            "user_name": user.name,
+        }
+        
+        # Merge app_metadata if provided and valid
+        if app_metadata and isinstance(app_metadata, dict):
+            log_metadata["app_metadata"] = app_metadata
+        
         log_entry = ZhealthLogs.create_log(
             user_id=user.id,
             user_email=user.email,
@@ -1536,12 +1551,7 @@ def _create_zhealth_log_entry(user, model_id: str | None, form_data: dict):
                 "frequency_penalty": form_data.get("frequency_penalty"),
                 "presence_penalty": form_data.get("presence_penalty"),
             },
-            log_metadata={
-                "api_version": "v1",
-                "endpoint": "/api/zhealth/v1/chat/completions",
-                "user_role": user.role,
-                "user_name": user.name,
-            }
+            log_metadata=log_metadata
         )
         if log_entry:
             log.info(f"Created zhealth log entry: {log_entry.id}")
@@ -1655,6 +1665,17 @@ async def zhealth_chat_completion(
     """
     Zhealth-specific chat completion endpoint that logs all requests, responses,
     citations, and middleware events to Supabase.
+    
+    Accepts optional 'app_metadata' field in request body for application identification:
+    {
+        "model": "gpt-4",
+        "messages": [...],
+        "app_metadata": {
+            "app_name": "MyApp",
+            "app_version": "1.0.0",
+            "environment": "production"
+        }
+    }
     """
     model_id = form_data.get("model", None)
     log_id = _create_zhealth_log_entry(user, model_id, form_data)


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? (Updated in-code docstring)
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes? (Self-tested during conversation)
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

This PR introduces the ability to include custom `app_metadata` in requests to the `/api/zhealth/v1/chat/completions` endpoint. This optional metadata, provided as a dictionary, will be stored within the `log_metadata` field in the `zhealth_logs` table in Supabase. This allows users to distinguish and track requests originating from different applications or client environments, enhancing observability and analytics without affecting core functionality. The implementation is robust, optional, and backward-compatible.

### Added

- Support for an optional `app_metadata` dictionary in the request body of `/api/zhealth/v1/chat/completions`.
- `app_metadata` is now stored within the `log_metadata` JSONB field in `zhealth_logs` in Supabase.

### Changed

- The `_create_zhealth_log_entry` function to extract and merge `app_metadata` into the log entry.
- The docstring for `zhealth_chat_completion` to document the new `app_metadata` field.

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- None

### Breaking Changes

